### PR TITLE
relicense message parser under name of development team

### DIFF
--- a/src/irc/message/LICENSE
+++ b/src/irc/message/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Rylee Fowler <rylee@rylee.me>
+Copyright (c) 2015 Charon Development Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
For purpose of later merging license under that of the project as a whole